### PR TITLE
Fix build and compilation error

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,11 +13,11 @@ seq(webSettings :_*)
 classpathTypes ~= (_ + "orbit")
 
 libraryDependencies ++= Seq(
-  "org.scalatra"                 % "scalatra"               % "2.2.0-SNAPSHOT",
-  "org.scalatra"                 % "scalatra-scalate"       % "2.2.0-SNAPSHOT",
-  "org.scalatra"                 % "scalatra-specs2"        % "2.2.0-SNAPSHOT"     % "test",
-  "org.scalatra"                 % "scalatra-swagger"       % "2.2.0-SNAPSHOT",
-  "org.scalatra"                 % "scalatra-json"          % "2.2.0-SNAPSHOT",
+  "org.scalatra"                 % "scalatra"               % "2.2.0",
+  "org.scalatra"                 % "scalatra-scalate"       % "2.2.0",
+  "org.scalatra"                 % "scalatra-specs2"        % "2.2.0"     % "test",
+  "org.scalatra"                 % "scalatra-swagger"       % "2.2.0",
+  "org.scalatra"                 % "scalatra-json"          % "2.2.0",
   "org.json4s"                  %% "json4s-jackson"         % "3.0.0",
   "ch.qos.logback"               % "logback-classic"        % "1.0.6" % "runtime",
   "org.eclipse.jetty"            % "jetty-webapp"           % "8.1.5.v20120716"     % "container",

--- a/src/main/scala/com/wordnik/swagger/sample/PetstoreApp.scala
+++ b/src/main/scala/com/wordnik/swagger/sample/PetstoreApp.scala
@@ -10,7 +10,7 @@ import org.json4s.{DefaultFormats, Formats}
 
 class ResourcesApp(implicit val swagger: Swagger) extends ScalatraServlet with JacksonSwaggerBase {
 
-  protected implicit val jsonFormats: Formats = DefaultFormats
+  override protected implicit val jsonFormats: Formats = DefaultFormats
 
 }
 


### PR DESCRIPTION
Remove legacy `org.scalatra` dependencies and add the `override` modifier to value `jsonFormats`. 

Build error: 
```
sbt.ResolveException: unresolved dependency: org.scalatra#scalatra;2.2.0-SNAPSHOT: not found
unresolved dependency: org.scalatra#scalatra-scalate;2.2.0-SNAPSHOT: not found
unresolved dependency: org.scalatra#scalatra-swagger;2.2.0-SNAPSHOT: not found
unresolved dependency: org.scalatra#scalatra-json;2.2.0-SNAPSHOT: not found
unresolved dependency: org.scalatra#scalatra-specs2;2.2.0-SNAPSHOT: not found
        at sbt.IvyActions$.sbt$IvyActions$$resolve(IvyActions.scala:211)
        at sbt.IvyActions$$anonfun$update$1.apply(IvyActions.scala:122)
        at sbt.IvyActions$$anonfun$update$1.apply(IvyActions.scala:121)
        at sbt.IvySbt$Module$$anonfun$withModule$1.apply(Ivy.scala:114)
        at sbt.IvySbt$Module$$anonfun$withModule$1.apply(Ivy.scala:114)
        at sbt.IvySbt$$anonfun$withIvy$1.apply(Ivy.scala:102)
        at sbt.IvySbt.liftedTree1$1(Ivy.scala:49)
        at sbt.IvySbt.action$1(Ivy.scala:49)
```