### PR TITLE
Get rid of the TypeParamSupport

### DIFF
--- a/src/main/scala/com/wordnik/swagger/sample/PetServlet.scala
+++ b/src/main/scala/com/wordnik/swagger/sample/PetServlet.scala
@@ -11,7 +11,7 @@ import org.scalatra.json._
 import scala.collection.JavaConverters._
 import org.json4s.{DefaultFormats, Formats}
 
-class PetServlet(implicit val swagger: Swagger) extends ScalatraServlet with TypedParamSupport with JacksonJsonSupport with JValueResult with SwaggerSupport {
+class PetServlet(implicit val swagger: Swagger) extends ScalatraServlet with JacksonJsonSupport with JValueResult with SwaggerSupport {
   import org.json4s.JsonDSL._
   protected val applicationDescription = "The pets api"
   override protected val applicationName = Some("pet")


### PR DESCRIPTION
Hi guys,

The TypeParamSupport is deprecated:
This got folded into core, so you can remove the TypeParamSupport trait safely.

No need to define this since 2.2.0:
http://www.scalatra.org/2.2/api/org/scalatra/TypedParamSupport.html

Cheers,
Fokko